### PR TITLE
Changed name to SourceContext when creating logger with a string name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+.vs/

--- a/src/SerilogFactoryAdapter.cs
+++ b/src/SerilogFactoryAdapter.cs
@@ -79,7 +79,7 @@ namespace Common.Logging.Serilog
         /// </returns>
         public ILog GetLogger(string name)
         {
-            return new SerilogCommonLogger(this.Logger.ForContext("name", name));
+            return new SerilogCommonLogger(this.Logger.ForContext("SourceContext", name));
         }
     }
 }


### PR DESCRIPTION
Fix for issue raised against JSNLog [#181](https://github.com/mperdeck/jsnlog/issues/181)